### PR TITLE
fixed readme downloading information (curl needs -L to follow redirect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ It is a spiritual successor to [AnzeigenOrg/ebayKleinanzeigen](https://github.co
 
    1. On Windows:
        ```batch
-       curl https://github.com/kleinanzeigen-bot/kleinanzeigen-bot/releases/download/latest/kleinanzeigen-bot-windows-amd64.exe -o kleinanzeigen-bot.exe
+       curl -L https://github.com/kleinanzeigen-bot/kleinanzeigen-bot/releases/download/latest/kleinanzeigen-bot-windows-amd64.exe -o kleinanzeigen-bot.exe
 
        kleinanzeigen-bot --help
        ```
 
    1. On Linux:
        ```shell
-       curl https://github.com/kleinanzeigen-bot/kleinanzeigen-bot/releases/download/latest/kleinanzeigen-bot-linux-amd64 -o kleinanzeigen-bot
+       curl -L https://github.com/kleinanzeigen-bot/kleinanzeigen-bot/releases/download/latest/kleinanzeigen-bot-linux-amd64 -o kleinanzeigen-bot
 
        chmod 655 kleinanzeigen-bot
 
@@ -61,7 +61,7 @@ It is a spiritual successor to [AnzeigenOrg/ebayKleinanzeigen](https://github.co
 
    1. On macOS:
        ```shell
-       curl https://github.com/kleinanzeigen-bot/kleinanzeigen-bot/releases/download/latest/kleinanzeigen-bot-darwin-amd64 -o kleinanzeigen-bot
+       curl -L https://github.com/kleinanzeigen-bot/kleinanzeigen-bot/releases/download/latest/kleinanzeigen-bot-darwin-amd64 -o kleinanzeigen-bot
 
        chmod 655 kleinanzeigen-bot
 


### PR DESCRIPTION
I added the "-L" switch to curl. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
